### PR TITLE
Improve filesystem module tests

### DIFF
--- a/modules/ChangeDirectory/tests/testsChangeDirectory.cpp
+++ b/modules/ChangeDirectory/tests/testsChangeDirectory.cpp
@@ -1,9 +1,6 @@
 #include "../ChangeDirectory.hpp"
 
-#ifdef __linux__
-#elif _WIN32
-#include <windows.h>
-#endif
+#include <filesystem>
 
 bool testChangeDirectory();
 
@@ -17,7 +14,7 @@ int main()
        std::cout << "[+] Sucess" << std::endl;
     else
        std::cout << "[-] Failed" << std::endl;
-    
+
     return !res;
 }
 
@@ -26,81 +23,81 @@ bool testChangeDirectory()
 {
     std::unique_ptr<ChangeDirectory> changeDirectory = std::make_unique<ChangeDirectory>();
 
+    std::filesystem::path original = std::filesystem::current_path();
+    std::filesystem::path temp = std::filesystem::temp_directory_path() / "c2core_change_dir_test";
+    std::filesystem::create_directories(temp);
+    std::cout << "original=" << original << " temp=" << temp << std::endl;
+
+    // Change to temporary directory
     {
         std::vector<std::string> splitedCmd;
         splitedCmd.push_back("cd");
-        splitedCmd.push_back("sdghdfhdfgnjdgf");
+        splitedCmd.push_back(temp.string());
 
         C2Message c2Message;
         C2Message c2RetMessage;
         changeDirectory->init(splitedCmd, c2Message);
+        c2Message.set_cmd(temp.string());
         changeDirectory->process(c2Message, c2RetMessage);
 
-        std::string output = "\n\noutput:\n";
-        output += c2RetMessage.returnvalue();
-        output += "\n";
-        std::cout << output << std::endl;
+        std::cout << "changed to: " << c2RetMessage.returnvalue() << std::endl;
+        if (c2RetMessage.returnvalue() != temp.string()) {
+            std::cout << "ret mismatch" << std::endl;
+            return false;
+        }
+        if (std::filesystem::current_path() != temp) {
+            std::cout << "cwd mismatch" << std::endl;
+            return false;
+        }
     }
+
+    // Invalid directory should not change current path
     {
         std::vector<std::string> splitedCmd;
         splitedCmd.push_back("cd");
-        splitedCmd.push_back("..");
+        splitedCmd.push_back("does_not_exist");
 
         C2Message c2Message;
         C2Message c2RetMessage;
         changeDirectory->init(splitedCmd, c2Message);
+        c2Message.set_cmd("does_not_exist");
         changeDirectory->process(c2Message, c2RetMessage);
 
-        std::string output = "\n\noutput:\n";
-        output += c2RetMessage.returnvalue();
-        output += "\n";
-        std::cout << output << std::endl;
+        std::cout << "invalid result: " << c2RetMessage.returnvalue() << std::endl;
+        if (c2RetMessage.returnvalue() != temp.string()) {
+            std::cout << "invalid ret mismatch" << std::endl;
+            return false;
+        }
+        if (std::filesystem::current_path() != temp) {
+            std::cout << "invalid cwd mismatch" << std::endl;
+            return false;
+        }
     }
+
+    // Return to original directory
     {
         std::vector<std::string> splitedCmd;
         splitedCmd.push_back("cd");
-        splitedCmd.push_back("C:\\Temp");
+        splitedCmd.push_back(original.string());
 
         C2Message c2Message;
         C2Message c2RetMessage;
         changeDirectory->init(splitedCmd, c2Message);
+        c2Message.set_cmd(original.string());
         changeDirectory->process(c2Message, c2RetMessage);
 
-        std::string output = "\n\noutput:\n";
-        output += c2RetMessage.returnvalue();
-        output += "\n";
-        std::cout << output << std::endl;
+        std::cout << "back result: " << c2RetMessage.returnvalue() << std::endl;
+        if (c2RetMessage.returnvalue() != original.string()) {
+            std::cout << "back ret mismatch" << std::endl;
+            return false;
+        }
+        if (std::filesystem::current_path() != original) {
+            std::cout << "back cwd mismatch" << std::endl;
+            return false;
+        }
     }
-    {
-        std::vector<std::string> splitedCmd;
-        splitedCmd.push_back("cd");
-        splitedCmd.push_back("...");
 
-        C2Message c2Message;
-        C2Message c2RetMessage;
-        changeDirectory->init(splitedCmd, c2Message);
-        changeDirectory->process(c2Message, c2RetMessage);
-
-        std::string output = "\n\noutput:\n";
-        output += c2RetMessage.returnvalue();
-        output += "\n";
-        std::cout << output << std::endl;
-    }
-    {
-        std::vector<std::string> splitedCmd;
-        splitedCmd.push_back("cd");
-        splitedCmd.push_back("C:\\");
-
-        C2Message c2Message;
-        C2Message c2RetMessage;
-        changeDirectory->init(splitedCmd, c2Message);
-        changeDirectory->process(c2Message, c2RetMessage);
-
-        std::string output = "\n\noutput:\n";
-        output += c2RetMessage.returnvalue();
-        output += "\n";
-        std::cout << output << std::endl;
-    }
+    std::filesystem::remove_all(temp);
 
     return true;
 }

--- a/modules/PrintWorkingDirectory/tests/testsPrintWorkingDirectory.cpp
+++ b/modules/PrintWorkingDirectory/tests/testsPrintWorkingDirectory.cpp
@@ -1,9 +1,6 @@
 #include "../PrintWorkingDirectory.hpp"
 
-#ifdef __linux__
-#elif _WIN32
-#include <windows.h>
-#endif
+#include <filesystem>
 
 bool testPrintWorkingDirectory();
 
@@ -18,26 +15,21 @@ int main()
     else
        std::cout << "[-] Failed" << std::endl;
 
-    return 0;
+    return !res;
 }
 
 bool testPrintWorkingDirectory()
 {
     std::unique_ptr<PrintWorkingDirectory> printWorkingDirectory = std::make_unique<PrintWorkingDirectory>();
-    {
-        std::vector<std::string> splitedCmd;
-        splitedCmd.push_back("pwd");
 
-        C2Message c2Message;
-        C2Message c2RetMessage;
-        printWorkingDirectory->init(splitedCmd, c2Message);
-        printWorkingDirectory->process(c2Message, c2RetMessage);
+    std::vector<std::string> splitedCmd;
+    splitedCmd.push_back("pwd");
 
-        std::string output = "\n\noutput:\n";
-        output += c2RetMessage.returnvalue();
-        output += "\n";
-        std::cout << output << std::endl;
-    }
+    C2Message c2Message;
+    C2Message c2RetMessage;
+    printWorkingDirectory->init(splitedCmd, c2Message);
+    printWorkingDirectory->process(c2Message, c2RetMessage);
 
-    return true;
+    std::string expected = std::filesystem::current_path().string();
+    return c2RetMessage.returnvalue() == expected;
 }


### PR DESCRIPTION
## Summary
- improve tests for directory-related modules
- check working directory output in PrintWorkingDirectory tests
- validate directory changes and error handling in ChangeDirectory tests
- verify ListDirectory output for valid and invalid paths
- overhaul Download and Upload tests for better coverage

## Testing
- `cmake -DWITH_TESTS=ON ..` *(fails: missing top-level CMake project)*
- `cmake --build . --target testsDownload`
- `cmake --build . --target testsUpload`
- `../Tests/testsDownload`
- `../Tests/testsUpload`
- `../Tests/testsChangeDirectory`
- `../Tests/testsListDirectory`
- `../Tests/testsPrintWorkingDirectory`


------
https://chatgpt.com/codex/tasks/task_e_688a230420cc83259d2685decc64e6cb