### PR TITLE
Add Windows shell

### DIFF
--- a/modules/Shell/Shell.hpp
+++ b/modules/Shell/Shell.hpp
@@ -16,18 +16,19 @@ public:
     int errorCodeToMsg(const C2Message &c2RetMessage, std::string& errorMsg);
     int osCompatibility()
     {
-        return OS_LINUX;
+        return OS_LINUX | OS_WINDOWS;
     }
 
 private:
     int startShell();
     void stopShell();
 
-    int m_masterFd;
-
 #ifdef _WIN32
-    int m_pid;
+    HANDLE m_hChildStdoutRd;
+    HANDLE m_hChildStdinWr;
+    PROCESS_INFORMATION m_pi;
 #else
+    int m_masterFd;
     pid_t m_pid;
 #endif
     std::string m_program;

--- a/modules/Shell/Shell.hpp
+++ b/modules/Shell/Shell.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #include "ModuleCmd.hpp"
 
 class Shell : public ModuleCmd


### PR DESCRIPTION
## Summary
- enable Shell module on Windows
- implement Windows-specific process management for interactive shell
- broaden OS compatibility to Windows

## Testing
- `cmake -DWITH_TESTS=ON ..`
- `make -j$(nproc)`
- `./testsShell`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688b5b0ae2688325a79815a11bf9d018