### PR TITLE
Fetch Coff dependencies for Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,20 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(SocksServer)
 
+if(WIN32)
+  FetchContent_Declare(
+    CoffPacker
+    GIT_REPOSITORY https://github.com/maxDcb/COFFPacker.git
+    GIT_TAG master
+  )
+  FetchContent_Declare(
+    CoffLoader
+    GIT_REPOSITORY https://github.com/maxDcb/COFFLoader.git
+    GIT_TAG main
+  )
+  FetchContent_MakeAvailable(CoffPacker CoffLoader)
+endif()
+
 # Header-only / source dependencies placed in thirdParty for relative includes
 set(BASE64_SRC_DIR ${CMAKE_SOURCE_DIR}/thirdParty/base64)
 FetchContent_Declare(


### PR DESCRIPTION
## Summary
- ensure CoffLoader module can link against CoffLoader and CoffPacker by fetching these libraries on Windows

## Testing
- `cmake -DC2CORE_BUILD_TESTS=ON ..`
- `cmake --build . -j` *(fails: build interrupted)*
- `ctest --output-on-failure` *(fails: Unable to find executable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b7cec23483258e43c0aaa103ed46