### PR TITLE
Refactor Beacon instruction handling

### DIFF
--- a/beacon/Beacon.hpp
+++ b/beacon/Beacon.hpp
@@ -4,15 +4,13 @@
 #include "../listener/ListenerSmb.hpp"
 #include "SocksTunnelClient.hpp"
 
-#ifdef __linux__
-#elif _WIN32
-#include <Windows.h>
-#endif
-
-#include <iostream>
-#include <chrono>
 #include <queue>
-#include <mutex>
+#include <string>
+#include <vector>
+#include <memory>
+#include <unordered_map>
+
+#include <nlohmann/json.hpp>
 
 #include "Common.hpp"
 
@@ -20,8 +18,8 @@
 class Beacon
 {
 public:
-	Beacon();
-	virtual ~Beacon(){};
+        Beacon();
+        virtual ~Beacon() = default;
 
 	bool initConfig(const std::string& config);
 	void run();
@@ -47,15 +45,26 @@ protected:
 	std::string m_pid;
 	std::string m_additionalInfo;
 
-	std::queue<C2Message> m_tasks;
-	std::queue<C2Message> m_taskResult;
+        std::queue<C2Message> m_tasks;
+        std::queue<C2Message> m_taskResult;
 
 private:
-	std::string m_key;
-	nlohmann::json m_modulesConfig;
+        std::string m_key;
+        nlohmann::json m_modulesConfig;
 
-	std::vector<std::unique_ptr<ModuleCmd>> m_moduleCmd;
-	std::vector<std::unique_ptr<Listener>> m_listeners;
-	std::vector<std::unique_ptr<SocksTunnelClient>> m_socksTunnelClient;
+        std::vector<std::unique_ptr<ModuleCmd>> m_moduleCmd;
+        std::vector<std::unique_ptr<Listener>> m_listeners;
+        std::vector<std::unique_ptr<SocksTunnelClient>> m_socksTunnelClient;
+
+        using InstructionHandler = bool (Beacon::*)(C2Message&, C2Message&);
+        std::unordered_map<std::string, InstructionHandler> m_instructionHandlers;
+
+        bool handleEndInstruction(C2Message& c2Message, C2Message& c2RetMessage);
+        bool handleSleepInstruction(C2Message& c2Message, C2Message& c2RetMessage);
+        bool handleListenerInstruction(C2Message& c2Message, C2Message& c2RetMessage);
+        bool handleSocks5Instruction(C2Message& c2Message, C2Message& c2RetMessage);
+        bool handleLoadModuleInstruction(C2Message& c2Message, C2Message& c2RetMessage);
+        bool handleUnloadModuleInstruction(C2Message& c2Message, C2Message& c2RetMessage);
+        bool handleModuleInstruction(C2Message& c2Message, C2Message& c2RetMessage);
 
 };

--- a/beacon/tests/testBeacon.cpp
+++ b/beacon/tests/testBeacon.cpp
@@ -24,6 +24,12 @@ TEST_CASE("initConfig parses xor key", "[beacon]") {
     REQUIRE(b.initConfig(kConfig));
 }
 
+TEST_CASE("initConfig validates input", "[beacon]") {
+    BeaconTestProxy b;
+    REQUIRE_FALSE(b.initConfig("not json"));
+    REQUIRE_FALSE(b.initConfig(R"({"xorKey":"k"})"));
+}
+
 TEST_CASE("cmdToTasks handles malformed input", "[beacon]") {
     BeaconTestProxy b;
     b.initConfig(kConfig);
@@ -59,4 +65,12 @@ TEST_CASE("execInstruction handles Sleep and End", "[beacon]") {
     C2Message endRet;
     REQUIRE(b.execInstruction(endMsg, endRet));
     REQUIRE(endRet.returnvalue() == CmdStatusSuccess);
+}
+
+TEST_CASE("execInstruction unknown module", "[beacon]") {
+    BeaconTestProxy b;
+    C2Message msg; msg.set_instruction("UNKNOWN");
+    C2Message ret;
+    REQUIRE_FALSE(b.execInstruction(msg, ret));
+    REQUIRE(ret.returnvalue() == CmdModuleNotFound);
 }


### PR DESCRIPTION
## Summary
- clean and self-contain Beacon header
- refactor beacon instruction dispatch into discrete handlers
- add configuration validation and jittered sleep

## Testing
- :warning: `cmake --build . --target beacon_unit_tests -j` *(build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a7089adc83258249bf174d267f56