### PR TITLE
Fix RawWinRm build dependencies

### DIFF
--- a/modules/RawWinRm/CMakeLists.txt
+++ b/modules/RawWinRm/CMakeLists.txt
@@ -1,8 +1,6 @@
 add_library(RawWinRm SHARED RawWinRm.cpp)
 set_property(TARGET RawWinRm PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded")
 
-target_link_libraries(RawWinRm PRIVATE ModuleCmd)
-
 if (WIN32)
     target_link_libraries(RawWinRm PRIVATE winhttp ws2_32 crypt32 ole32 advapi32)
 endif()
@@ -12,7 +10,6 @@ add_custom_command(TARGET RawWinRm POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy
 
 if(C2CORE_BUILD_TESTS)
     add_executable(testsRawWinRm tests/testsRawWinRm.cpp RawWinRm.cpp)
-    target_link_libraries(testsRawWinRm PRIVATE ModuleCmd)
     if (WIN32)
         target_link_libraries(testsRawWinRm PRIVATE winhttp ws2_32 crypt32 ole32 advapi32)
     endif()

--- a/modules/RawWinRm/RawWinRm.cpp
+++ b/modules/RawWinRm/RawWinRm.cpp
@@ -1,6 +1,6 @@
 #include "RawWinRm.hpp"
 
-#include "ModuleCmd/Common.hpp"
+#include "Common.hpp"
 
 #include <algorithm>
 #include <array>


### PR DESCRIPTION
## Summary
- adjust the RawWinRm include to use the existing ModuleCmd headers
- stop linking the RawWinRm targets against a non-existent ModuleCmd library

## Testing
- cmake --build . --target testsRawWinRm
- ctest -R testsRawWinRm --output-on-failure


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691705d20fc88325b74c50726a7935ab)